### PR TITLE
Allow passing collation type via REST using query filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ of type `GeoPoint`. This allows for indexed ```near``` queries.  Default is `fal
   - It will try to establish the connection automatically once users hit the endpoint. If the mongodb server is offline, the app will start, however, the endpoints will not work.
 - **disableDefaultSort**: Set to `true` to disable the default sorting
   behavior on `id` column, this will help performance using indexed columns available in mongodb.
+- **collation**: Specify language-specific rules for string comparison, such as rules for lettercase and accent marks. See [`MongdoDB documentation`](https://docs.mongodb.com/manual/reference/collation/) for details. It can also be used to create [`case insensitive indexes`](https://docs.mongodb.com/manual/core/index-case-insensitive/).
 
 ### Setting the url property in datasource.json
 

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -1241,7 +1241,7 @@ MongoDB.prototype.all = function all(model, filter, options, callback) {
       return callback(err);
     }
 
-    var collation = options && options.collation;
+    var collation = sanitizeCollation(filter.collation || (options && options.collation), options);
     if (collation) {
       cursor.collation(collation);
     }
@@ -1824,6 +1824,41 @@ function sanitizeFilter(filter, options) {
 }
 
 exports.sanitizeFilter = sanitizeFilter;
+
+const collationTypes = {
+  locale: 'string',
+  caseLevel: 'boolean',
+  caseFirst: 'string',
+  strength: 'number',
+  numericOrdering: 'boolean',
+  alternate: 'string',
+  maxVariable: 'string',
+  backwards: 'boolean',
+};
+
+function sanitizeCollation(collation, options) {
+  const _collation = {};
+  let hasKey = false;
+
+  options = Object.assign({}, options);
+  if (options.disableSanitization) return collation;
+  if (!collation || typeof collation !== 'object') return;
+
+  for (const key in collationTypes) {
+    const val = collation[key];
+    const type = collationTypes[key];
+    if (val && typeof val === type) {
+      _collation[key] = val;
+      hasKey = true;
+    } else {
+      debug(`sanitizeCollation: deleting ${key}`);
+    }
+  }
+
+  return hasKey && _collation;
+}
+
+exports.sanitizeCollation = sanitizeCollation;
 
 /**
  * Find a matching model instances by the filter or create a new instance

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -1241,6 +1241,11 @@ MongoDB.prototype.all = function all(model, filter, options, callback) {
       return callback(err);
     }
 
+    var collation = options && options.collation;
+    if (collation) {
+      cursor.collation(collation);
+    }
+
     // don't apply sorting if dealing with a geo query
     if (!hasNearFilter(filter.where)) {
       var order = self.buildSort(model, filter.order, options);

--- a/test/mongodb.test.js
+++ b/test/mongodb.test.js
@@ -507,10 +507,10 @@ describe('mongodb connector', function() {
     db.automigrate('Category', function() {
       db.connector.db.collection('Category').indexes(function(err, result) {
         var indexes = [
-          { name: '_id_', key: { _id: 1 }},
-          { name: 'title_1', key: { title: 1 }},
-          { name: 'title_case_insensitive', key: { title: 1 }, collation: { locale: 'en', strength: 1 }},
-          { name: 'posts_1', key: { posts: 1 }},
+          {name: '_id_', key: {_id: 1}},
+          {name: 'title_1', key: {title: 1}},
+          {name: 'title_case_insensitive', key: {title: 1}, collation: {locale: 'en', strength: 1}},
+          {name: 'posts_1', key: {posts: 1}},
         ];
 
         result.should.containDeep(indexes);
@@ -2616,12 +2616,12 @@ describe('mongodb connector', function() {
   });
 
   it('should allow to find using case insensitive index', function(done) {
-    Category.create({ title: 'My Category' }, function(err, category1) {
+    Category.create({title: 'My Category'}, function(err, category1) {
       should.not.exist(err);
-      Category.create({ title: 'MY CATEGORY' }, function(err, category2) {
+      Category.create({title: 'MY CATEGORY'}, function(err, category2) {
         should.not.exist(err);
 
-        Category.find({ where: { title: 'my cATEGory' }}, { collation: { locale: 'en', strength: 1 }},
+        Category.find({where: {title: 'my cATEGory'}}, {collation: {locale: 'en', strength: 1}},
           function(err, categories) {
             should.not.exist(err);
             categories.should.have.length(2);

--- a/test/mongodb.test.js
+++ b/test/mongodb.test.js
@@ -2617,9 +2617,9 @@ describe('mongodb connector', function() {
 
   it('should allow to find using case insensitive index', function(done) {
     Category.create({ title: 'My Category' }, function(err, category1) {
-      should.not.exists(err);
+      should.not.exist(err);
       Category.create({ title: 'MY CATEGORY' }, function(err, category2) {
-        should.not.exists(err);
+        should.not.exist(err);
 
         Category.find({ where: { title: 'my cATEGory' }}, { collation: { locale: 'en', strength: 1 }},
           function(err, categories) {


### PR DESCRIPTION
### Description

Hi Maxim, Thanks a lot for your PR on support for collations. 
We are requiring an extension to your initial PR to support different sorting for different languages. 
So maybe you are interested in piggybacking this PR with yours.
Please let me know your opinion. Thanks Sebastian

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to #414

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
